### PR TITLE
Remove a described carriage return

### DIFF
--- a/Assignment-1.md
+++ b/Assignment-1.md
@@ -92,7 +92,6 @@ host:httpbin.org
 Content-type:text/plain
 Content-length:12
 [carriage return]
-[carriage return]
 Hello World!
 [carriage return]
 ```


### PR DESCRIPTION
In this commit, I have removed one of the carriage returns in the PUT code snippet given. This is the case because the code snippet in before the change suggests that two carriage returns are below the `Content-length:12` line and before `Hello World!`. However,  instead, only one carriage return should be between the two, hence the removal.