### PR TITLE
fixed a grammatical mistake

### DIFF
--- a/How-to-use-VSC.md
+++ b/How-to-use-VSC.md
@@ -1,4 +1,4 @@
-Table of Content
+Table of Contents
 ==
 
 - [How to use VSC](#how-to-use-vsc)


### PR DESCRIPTION
"Table of Content" is written "Table of contents" by convention