### PR TITLE
Change from the old TI prefix to the new CSE prefix

### DIFF
--- a/Lecture-node2.md
+++ b/Lecture-node2.md
@@ -505,7 +505,7 @@ Apart from regular expressions, routing parameters can be employed to enable **v
 
 ```javascript
 var todoTypes = {
-    important: ["TI1500","ADS","Calculus"],
+    important: ["CSE1500","ADS","Calculus"],
     urgent: ["Dentist","Hotel booking"],
     unimportant: ["Groceries"],
 };
@@ -526,7 +526,7 @@ Routing parameters can have various levels of nesting :point_down::
 ```javascript
 var todoTypes = {
     important: {
-        today: ["TI1500"],
+        today: ["CSE1500"],
         tomorrow: ["ADS", "Calculus"]
     },
     urgent: {

--- a/Lecture-security.md
+++ b/Lecture-security.md
@@ -273,7 +273,7 @@ var isEmail = validator.isEmail('while(1)'); //false
 
 #### SQL injections
 
-SQL injections are of such great practical importance that we will dedicate more time to them in a later course: they will be covered in TI1505!
+SQL injections are of such great practical importance that we will dedicate more time to them in a later course: they will be covered in [CSE1505](https://studiegids.tudelft.nl/a101_displayCourse.do?course_id=48439)!
 
 
 ### Broken authentication
@@ -447,7 +447,7 @@ Web applications often make use of *Direct Object References* when generating a 
 
 ```javascript
 var todoTypes = {
-    important: ["TI1506","OOP","Calculus"],
+    important: ["CSE1500","ADS","Calculus"],
     urgent: ["Dentist","Hotel booking"],
     unimportant: ["Groceries"],
 };


### PR DESCRIPTION
Hi!

I noticed while studying for the endterm that there were a few instances where the old TI- prefix for course was being used instead of the new CSE prefix. 

This commit changes those over, adds a link to the CSE1505 course syllabus page and synchronizes the TODO example used in Lecture 15 & 17 since I think those were supposed to be the same. 

Have a nice day. 

Cheers, 

Valentijn